### PR TITLE
 Fix unicode session behavior

### DIFF
--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for more details.
 """
 import time
+import sys
 from datetime import datetime
 from uuid import uuid4
 try:
@@ -446,7 +447,7 @@ class SqlAlchemySessionInterface(SessionInterface):
 
                 id = self.db.Column(self.db.Integer, primary_key=True)
                 session_id = self.db.Column(self.db.String(256), unique=True)
-                data = self.db.Column(self.db.Text)
+                data = self.db.Column(self.db.LargeBinary)
                 expiry = self.db.Column(self.db.DateTime)
 
                 def __init__(self, session_id, data, expiry):
@@ -484,12 +485,8 @@ class SqlAlchemySessionInterface(SessionInterface):
             self.db.session.commit()
             saved_session = None
         if saved_session:
-            try:
-                val = saved_session.data
-                data = self.serializer.loads(str(val))
-                return self.session_class(data, sid=sid)
-            except:
-                return self.session_class(sid=sid)
+            data = self.serializer.loads(saved_session.data)
+            return self.session_class(data, sid=sid)
         return self.session_class(sid=sid)
 
     def save_session(self, app, session, response):


### PR DESCRIPTION
This converts the data field to a large binary and assumes Unicode values instead of string data.

@3noch  can you review this  since we don't have CI for this.
